### PR TITLE
Sending empty header if the id token was not there

### DIFF
--- a/ClientApp/src/app/services/activity-tracker.service.ts
+++ b/ClientApp/src/app/services/activity-tracker.service.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class ActivityTrackerService {
-  constructor(private http: HttpClient, @Inject('BASE_URL') private baseUrl: string) {}
+  constructor(private http: HttpClient, @Inject('BASE_URL') private baseUrl: string) { }
 
   // An observable is a stream of events that you can listen to.
   public createUser(): Observable<User> {
@@ -23,6 +23,11 @@ export class ActivityTrackerService {
   private getAuthHeaders() {
     const accessToken = localStorage.getItem('access_token');
     const idToken = localStorage.getItem('id_token');
+    if (idToken == null) {
+      return {
+        headers: new HttpHeaders()
+      };
+    }
     const httpOptions = {
       headers: new HttpHeaders({
         'Content-Type': 'application/json',


### PR DESCRIPTION
Was sending an empty header, now if the auth headers are not valid it does not add them.